### PR TITLE
Fix: non-BMP kanji not handled properly

### DIFF
--- a/kanbun.js
+++ b/kanbun.js
@@ -38,7 +38,7 @@ function replaceBetween(str, left, right, from, to, condition = function () { re
 }
 
 function toHTML(str) {
-    let arr = str.split('');
+    let arr = [...str];
     for (let i = 0, lastBracketIndex = -1; i < arr.length; i++) {
         if (leftBrackets.includes(arr[i])) lastBracketIndex = i;
         if (lastBracketIndex === -1) {


### PR DESCRIPTION
`str.split('')` does NOT split the string by Unicode code points but by
UTF-16 code units, causing non-BMP kanji being split into surrogate
pairs.

The correct way for turning a string into an array is `str.split()` or
`[...str]`.
